### PR TITLE
Add influencerlink.org

### DIFF
--- a/strings.json
+++ b/strings.json
@@ -114,5 +114,6 @@
     "mudwtr.com",
     "365Games",
     "Codeium",
-    "nvda.ws"
+    "nvda.ws",
+    "influencerlink.org"
 ]


### PR DESCRIPTION
Used in the string:
`Capture/Contain/Bind your best gaming moments. Eat!/Download!! Outplayed free: https://www.influencerlink.org/SHKXC`
Can't really add any of the other words, as they are too generic. Block the URL instead, might also block other sponsors.